### PR TITLE
Update dependencies for postgres connector to reduce scope for dup classes in classpath

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ apply plugin: 'nebula-aggregate-javadocs'
 allprojects {
 
     group = 'org.odpi.egeria'
-    version = '2.5-SNAPSHOT'
+    version = '2.6-SNAPSHOT'
 
     repositories {
          jcenter()
@@ -78,10 +78,10 @@ subprojects {
     dependencies {
         constraints {
             implementation("org.slf4j:slf4j-api:1.7.30")
-            implementation 'org.odpi.egeria:data-manager-client:2.5-SNAPSHOT'
-            implementation 'org.odpi.egeria:data-manager-api:2.5-SNAPSHOT'
-            implementation 'org.odpi.egeria:database-integrator-api:2.5-SNAPSHOT'
-            implementation 'org.odpi.egeria:open-connector-framework:2.5-SNAPSHOT'
+            implementation 'org.odpi.egeria:data-manager-client:2.6-SNAPSHOT'
+            implementation 'org.odpi.egeria:data-manager-api:2.6-SNAPSHOT'
+            implementation 'org.odpi.egeria:database-integrator-api:2.6-SNAPSHOT'
+            implementation 'org.odpi.egeria:open-connector-framework:2.6-SNAPSHOT'
             implementation 'org.slf4j:slf4j-api'
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -75,14 +75,9 @@ subprojects {
     apply plugin: 'maven-publish'
 
     // Dependency Management - to fix versions. Pick up maven build settings for now
+    // Unnecessary for now as we have a single module
     dependencies {
         constraints {
-            implementation("org.slf4j:slf4j-api:1.7.30")
-            implementation 'org.odpi.egeria:data-manager-client:2.6-SNAPSHOT'
-            implementation 'org.odpi.egeria:data-manager-api:2.6-SNAPSHOT'
-            implementation 'org.odpi.egeria:database-integrator-api:2.6-SNAPSHOT'
-            implementation 'org.odpi.egeria:open-connector-framework:2.6-SNAPSHOT'
-            implementation 'org.slf4j:slf4j-api'
         }
 
         test {

--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,11 @@ subprojects {
     // Unnecessary for now as we have a single module
     dependencies {
         constraints {
+            compileOnly 'org.odpi.egeria:data-manager-client:2.6-SNAPSHOT'
+            compileOnly 'org.odpi.egeria:data-manager-api:2.6-SNAPSHOT'
+            compileOnly 'org.odpi.egeria:database-integrator-api:2.6-SNAPSHOT'
+            compileOnly 'org.odpi.egeria:open-connector-framework:2.6-SNAPSHOT'
+            implementation 'org.slf4j:slf4j-api:1.7.30'
         }
 
         test {

--- a/build.gradle
+++ b/build.gradle
@@ -101,7 +101,6 @@ subprojects {
     test {
         useJUnitPlatform()
         dependencies {
-            testCompile("org.junit.jupiter:junit-jupiter-api:5.7.0")
             testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.7.0"
             testImplementation "org.junit.jupiter:junit-jupiter-params:5.7.0"
             testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.0")

--- a/postgres-connector/build.gradle
+++ b/postgres-connector/build.gradle
@@ -5,11 +5,10 @@
 
 
 dependencies {
-    implementation 'org.junit.jupiter:junit-jupiter:5.4.2'
-    implementation 'org.odpi.egeria:data-manager-client'
-    implementation 'org.odpi.egeria:data-manager-api'
-    implementation 'org.odpi.egeria:database-integrator-api'
-    implementation 'org.odpi.egeria:open-connector-framework'
+    compileOnly 'org.odpi.egeria:data-manager-client'
+    compileOnly 'org.odpi.egeria:data-manager-api'
+    compileOnly 'org.odpi.egeria:database-integrator-api'
+    compileOnly 'org.odpi.egeria:open-connector-framework'
     implementation 'org.slf4j:slf4j-api'
 }
 


### PR DESCRIPTION
Fixes #12 

 - Updates egeria version to 2.6 snapshot (note it is ALREADY using the odpi snapshot repo, which is appropriate in early stages development. Once released we should switch to using full egeria releases)
 - Changes scope of egeria dependencies to 'compileOnly'
 - updates constraints for package versions 
 - removes usage of deprecated testCompile scope
 
 @mandy-chessell @wbittles @davidradl This is a proposal I have for how it might be better to express the dependencies for the connector upon base egeria. It is a moving target and we're learning as we work through this. Appreciate your thoughts on whether this makes sense.
 
 See the main egeria issue for where we should improve our assemblies and documentation.