### PR TITLE
Build updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,13 @@ subprojects {
     ext {
         egeriaVersion = '2.9-SNAPSHOT'
     }
-    // Dependency Management - to fix versions. Pick up maven build settings for now
+
+    // ensures we pick up the very latest snapshots when built
+    configurations.all {
+        // check for updates every build
+        resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
+    }
+
     dependencies {
         constraints
                 {

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ apply plugin: 'nebula-aggregate-javadocs'
 allprojects {
 
     group = 'org.odpi.egeria'
-    version = '2.8-SNAPSHOT'
+    version = '2.9-SNAPSHOT'
 
     repositories {
          mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,11 @@
 */
 
 buildscript {
-    repositories { 
-        maven { url("https://odpi.jfrog.io/odpi/egeria-snapshot") }
+    repositories {
+    mavenCentral()
+    maven {
+        url "https://oss.sonatype.org/content/repositories/snapshots"
+        }
     }
 
     dependencies {
@@ -43,13 +46,12 @@ allprojects {
     version = '2.8-SNAPSHOT'
 
     repositories {
-         jcenter()
          mavenCentral()
          // snapshots of egeria core ie -SNAPSHOT
-         //TODO BELOW ISN'T WORKING
-         maven { url("https://odpi.jfrog.io/odpi/egeria-snapshot") }
-         maven { url("https://oss.sonatype.org/content/repositories/snapshots")}
-    }
+         maven {
+             url "https://oss.sonatype.org/content/repositories/snapshots"
+             }
+         }
 
 
     // This enforces version checking but is slow to process

--- a/build.gradle
+++ b/build.gradle
@@ -81,10 +81,10 @@ subprojects {
                 {
                     implementation 'org.postgresql:postgresql:42.2.19'
                     implementation 'org.slf4j:slf4j-api:latest.integration'
-                    implementation 'org.odpi.egeria:data-manager-client:2.8-SNAPSHOT'
-                    implementation 'org.odpi.egeria:data-manager-api:2.8-SNAPSHOT'
-                    implementation 'org.odpi.egeria:database-integrator-api:2.8-SNAPSHOT'
-                    implementation 'org.odpi.egeria:open-connector-framework:2.8-SNAPSHOT'
+                    implementation 'org.odpi.egeria:data-manager-client:2.9-SNAPSHOT'
+                    implementation 'org.odpi.egeria:data-manager-api:2.9-SNAPSHOT'
+                    implementation 'org.odpi.egeria:database-integrator-api:2.9-SNAPSHOT'
+                    implementation 'org.odpi.egeria:open-connector-framework:2.9-SNAPSHOT'
                 }
         test {
             useJUnitPlatform {

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
 
     dependencies {
         classpath 'com.netflix.nebula:gradle-aggregate-javadocs-plugin:3.0.1'
-    } 
+    }
 }
 
 /*
@@ -75,16 +75,19 @@ subprojects {
     // As we've migrated from maven - we'll assume all submodules publish directly to maven
     apply plugin: 'maven-publish'
 
+    ext {
+        egeriaVersion = '2.9-SNAPSHOT'
+    }
     // Dependency Management - to fix versions. Pick up maven build settings for now
     dependencies {
         constraints
                 {
-                    implementation 'org.postgresql:postgresql:42.2.19'
-                    implementation 'org.slf4j:slf4j-api:latest.integration'
-                    implementation 'org.odpi.egeria:data-manager-client:2.9-SNAPSHOT'
-                    implementation 'org.odpi.egeria:data-manager-api:2.9-SNAPSHOT'
-                    implementation 'org.odpi.egeria:database-integrator-api:2.9-SNAPSHOT'
-                    implementation 'org.odpi.egeria:open-connector-framework:2.9-SNAPSHOT'
+                    implementation "org.postgresql:postgresql:42.2.19"
+                    implementation "org.slf4j:slf4j-api:1.7.30"
+                    implementation "org.odpi.egeria:data-manager-client:${egeriaVersion}"
+                    implementation "org.odpi.egeria:data-manager-api:${egeriaVersion}"
+                    implementation "org.odpi.egeria:database-integrator-api:${egeriaVersion}"
+                    implementation "org.odpi.egeria:open-connector-framework:${egeriaVersion}"
                 }
         test {
             useJUnitPlatform {

--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,15 @@ subprojects {
 
     // Dependency Management - to fix versions. Pick up maven build settings for now
     dependencies {
+        constraints
+                {
+                    implementation 'org.postgresql:postgresql:42.2.19'
+                    implementation 'org.slf4j:slf4j-api:latest.integration'
+                    implementation 'org.odpi.egeria:data-manager-client:2.8-SNAPSHOT'
+                    implementation 'org.odpi.egeria:data-manager-api:2.8-SNAPSHOT'
+                    implementation 'org.odpi.egeria:database-integrator-api:2.8-SNAPSHOT'
+                    implementation 'org.odpi.egeria:open-connector-framework:2.8-SNAPSHOT'
+                }
         test {
             useJUnitPlatform {
                 includeEngines 'junit-jupiter'

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ apply plugin: 'nebula-aggregate-javadocs'
 allprojects {
 
     group = 'org.odpi.egeria'
-    version = '2.5-SNAPSHOT'
+    version = '2.8-SNAPSHOT'
 
     repositories {
          jcenter()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/open-metadata-assemblies
+++ b/open-metadata-assemblies
@@ -1,1 +1,0 @@
-/home/wbittles/egeria2/egeria/open-metadata-distribution/open-metadata-assemblies/

--- a/postgres-connector/build.gradle
+++ b/postgres-connector/build.gradle
@@ -16,7 +16,7 @@ apply plugin: 'java'
 
 dependencies {
             implementation 'org.postgresql:postgresql'
-            implementation 'org.slf4j:slf4j-api:latest.integration'
+            implementation 'org.slf4j:slf4j-api'
             implementation 'org.odpi.egeria:data-manager-client'
             implementation 'org.odpi.egeria:data-manager-api'
             implementation 'org.odpi.egeria:database-integrator-api'

--- a/postgres-connector/build.gradle
+++ b/postgres-connector/build.gradle
@@ -47,7 +47,7 @@ jar {
 */
     task copyJarToBin {
         copy {
-            from 'build/libs/postgres-connector-2.5-SNAPSHOT.jar'
+            from 'build/libs/postgres-connector-2.9-SNAPSHOT.jar'
             into "libs"
         }
 }

--- a/postgres-connector/build.gradle
+++ b/postgres-connector/build.gradle
@@ -15,12 +15,12 @@ apply plugin: 'java'
 }
 
 dependencies {
-            implementation 'org.postgresql:postgresql:42.2.19'
+            implementation 'org.postgresql:postgresql'
             implementation 'org.slf4j:slf4j-api:latest.integration'
-            implementation 'org.odpi.egeria:data-manager-client:2.8-SNAPSHOT'
-            implementation 'org.odpi.egeria:data-manager-api:2.8-SNAPSHOT'
-            implementation 'org.odpi.egeria:database-integrator-api:2.8-SNAPSHOT'
-            implementation 'org.odpi.egeria:open-connector-framework:2.8-SNAPSHOT'
+            implementation 'org.odpi.egeria:data-manager-client'
+            implementation 'org.odpi.egeria:data-manager-api'
+            implementation 'org.odpi.egeria:database-integrator-api'
+            implementation 'org.odpi.egeria:open-connector-framework'
   }
 
 

--- a/postgres-connector/build.gradle
+++ b/postgres-connector/build.gradle
@@ -47,7 +47,7 @@ jar {
 */
     task copyJarToBin {
         copy {
-            from 'build/libs/postgres-connector-2.9-SNAPSHOT.jar'
+            from 'build/libs/postgres-connector-${version}.jar'
             into "libs"
         }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,6 +13,6 @@ pluginManagement {
         //id 'maven-publish' version
     }
 }
-rootProject.name = 'egeria'
+rootProject.name = 'egeria-database-connectors'
 
 include(':postgres-connector')


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

Fixes: #14 

- Upgrade gradle wrapper to 6.8.3
- Correct project name to 'egeria-database-connectors'
- Update group version to 2.8
- Ensure maven central snapshot repo used for build scripts and artifacts
- remove references to jfrog/jcenter repos
- remove empry directory
- re-implement constraints as the mechanism for specifying particular version for consistency (follows egeria pattern) 
- correct reference to version of jar being copied as binary
- update version of dependencies & component to 2.9
- parameterize egeria version for simpler updating

