### PR TITLE
#16 ensure artifact uploaded

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -47,5 +47,5 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Postgres Connector
-          path: postgres-connector/build/libs/*.jar
+          path: '**/build/libs/*.jar'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,4 +47,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Postgres Connector
-          path: postgres-connector/build/libs/*.jar
+          path: '**/build/libs/*.jar'

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -30,5 +30,5 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Postgres Connector
-          path: postgres-connector/build/libs/*.jar
+          path: '**/build/libs/*.jar'
 


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

* uploads connector produced by build as a build artifact ie attachment, to allow builds to be checked.