### PR TITLE
#16 remove maven local repo reference - causes inconsistent build beh…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,6 @@ buildscript {
     repositories {
         maven { url("https://oss.sonatype.org/content/repositories/snapshots") }
         mavenCentral()
-        mavenLocal()
     }
 
     dependencies {
@@ -53,7 +52,6 @@ allprojects {
 
     repositories {
          mavenCentral()
-         mavenLocal()
          maven { url("https://oss.sonatype.org/content/repositories/snapshots")}
     }
 


### PR DESCRIPTION
…aviour

- removes use of mavenlocal as a repository in build.gradle

This has been done as we should always build with a definitive version of external dependencies, which egeria itself is for the connector. Devs can override locally, but it needs to be clear we usually use a published copy.

This was the reason a build change wasn't immediately noticed and would work locally but not centrally

Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>