### PR TITLE
#65 skip setting owner in schema as no longer in DatabaseSchemaProper…

### DIFF
--- a/egeria-connector-postgres/src/main/java/org/odpi/openmetadata/adapters/connectors/integration/postgres/mapper/PostgresMapper.java
+++ b/egeria-connector-postgres/src/main/java/org/odpi/openmetadata/adapters/connectors/integration/postgres/mapper/PostgresMapper.java
@@ -52,7 +52,7 @@ public class PostgresMapper
         DatabaseSchemaProperties schemaProps = new DatabaseSchemaProperties();
         schemaProps.setDisplayName(sch.getQualifiedName());
         schemaProps.setQualifiedName(sch.getQualifiedName());
-        schemaProps.setOwner(sch.getSchema_owner());
+        //schemaProps.setOwner(sch.getSchema_owner());
         schemaProps.setAdditionalProperties(sch.getProperties());
 
         return schemaProps;


### PR DESCRIPTION
…ties

 - removes call to setOwner() on DatabaseSchemaProperties following recent changes in egeria 2.10-SNAPSHOT

Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>