### PR TITLE
#82 allow manual build to republish docker images & other artifacts

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -57,14 +57,14 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-        if: ${{ github.event_name == 'push' && github.repository == 'odpi/egeria-database-connectors' }}
+        if: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'push') && github.repository == 'odpi/egeria-database-connectors' }}
       # For releases (ie not main)
       - name: Build and push (not main merge)
         if: github.ref != 'refs/heads/main'
         id: docker_build_release
         uses: docker/build-push-action@v2
         with:
-          push: ${{ github.event_name == 'push' && github.repository == 'odpi/egeria-database-connectors' }}
+          push: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'push') && github.repository == 'odpi/egeria-database-connectors' }}
           tags: odpi/egeria-database-connectors:${{env.RELEASE_VERSION}}
           build-args: version=${{ env.RELEASE_VERSION }}
           context: .
@@ -75,7 +75,7 @@ jobs:
         id: docker_build_main
         uses: docker/build-push-action@v2
         with:
-          push: ${{ github.event_name == 'push' && github.repository == 'odpi/egeria-database-connectors' }}
+          push: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'push') && github.repository == 'odpi/egeria-database-connectors' }}
           tags: odpi/egeria-database-connectors:${{ env.RELEASE_VERSION}}, odpi/egeria-database-connectors:latest
           build-args: version=${{ env.RELEASE_VERSION }}
           context: .


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

* Ensures artifacts (maven, docker) republished when merge build manually rerun