### PR TITLE
Update postgres library version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ARG baseimage=odpi/egeria
 FROM ${baseimage}:${egeriaversion}
 
 ARG connectorversion=2.11-SNAPSHOT
-ARG postgresurl=https://jdbc.postgresql.org/download/postgresql-42.2.21.jar
+ARG postgresurl=https://jdbc.postgresql.org/download/postgresql-42.2.22.jar
 
 #ENV connectorversion ${connectorversion}
 #ENV egeriaversion ${egeriaversion}

--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,7 @@ subprojects {
     dependencies {
         constraints
                 {
-                    implementation "org.postgresql:postgresql:42.2.20"
+                    implementation "org.postgresql:postgresql:42.2.22"
                     implementation "org.slf4j:slf4j-api:1.7.30"
                     implementation "org.odpi.egeria:data-manager-client:${egeriaVersion}"
                     implementation "org.odpi.egeria:data-manager-api:${egeriaVersion}"


### PR DESCRIPTION
Replaces https://github.com/odpi/egeria-database-connectors/pull/90 so we can update the version in the dockerfile as well as gradle build (currently these are distinct)