### PR TITLE
Use consistent versions for building container image

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "Merge"
     env:
-      RELEASE_VERSION: 3.5-SNAPSHOT
+      RELEASE_VERSION: 3.6-SNAPSHOT
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # Thes are optional tags used to add additional metadata into the docker image
 # These may be supplied by the pipeline in future - until then they will default
 
-ARG egeriaversion=3.5
+ARG egeriaversion=3.6-SNAPSHOT
 ARG baseimage=docker.io/odpi/egeria
 
 # DEFER setting this for now, using the ${version}:

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ allprojects {
 
     // Published artifact info, equired for maven publishing - this is the version of our artifact
     group = 'org.odpi.egeria'
-    version = '3.5-SNAPSHOT'
+    version = '3.6-SNAPSHOT'
 
     apply plugin: 'idea'
 
@@ -59,7 +59,7 @@ allprojects {
 subprojects {
 
     ext {
-        egeriaVersion = '3.5'
+        egeriaVersion = '3.6-SNAPSHOT'
     }
 
     apply plugin: 'java-library'


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

* Updates versions of connector & egeria to '3.6-SNAPSHOT'

The current container image doesn't work correctly when used as a replacement image in the helm charts
In part this was due to a failing container build due to mismatched versions, but additionally in the charts the
same container is used for the ui-chassis, which was also a different version.

As a short term fix, the versions of all are set to align, ie 3.6-SNAPSHOT.

However the approach of using a replacement egeria docker image in the charts (at least for general use, vs a private ci/cd pipeline) is a) cumbersome to manage b) inflexible where multiple connectors need deploying.

In https://github.com/odpi/egeria-charts/issues/3 support is being added to the helm charts to instead use just the
connector jars - this pattern will also facilitate testing.