### PR TITLE
Update to 3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # Thes are optional tags used to add additional metadata into the docker image
 # These may be supplied by the pipeline in future - until then they will default
 
-ARG egeriaversion=3.6-SNAPSHOT
+ARG egeriaversion=3.5
 ARG baseimage=docker.io/odpi/egeria
 
 # DEFER setting this for now, using the ${version}:
@@ -16,7 +16,7 @@ ARG baseimage=docker.io/odpi/egeria
 
 FROM ${baseimage}:${egeriaversion}
 
-ARG connectorversion=3.6-SNAPSHOT
+ARG connectorversion=3.6
 ARG postgresurl=https://jdbc.postgresql.org/download/postgresql-42.2.23.jar
 
 #ENV connectorversion ${connectorversion}

--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,7 @@ subprojects {
     repositories {
         mavenCentral()
         maven { url("https://oss.sonatype.org/content/repositories/snapshots") }
+        mavenLocal()
     }
 
     // ensures we pick up the very latest snapshots when built

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ allprojects {
 
     // Published artifact info, equired for maven publishing - this is the version of our artifact
     group = 'org.odpi.egeria'
-    version = '3.6-SNAPSHOT'
+    version = '3.6'
 
     apply plugin: 'idea'
 
@@ -59,7 +59,7 @@ allprojects {
 subprojects {
 
     ext {
-        egeriaVersion = '3.6-SNAPSHOT'
+        egeriaVersion = '3.6'
     }
 
     apply plugin: 'java-library'


### PR DESCRIPTION
Updates connector version to 3.6 (but no release), using egeria 3.6 dependencies, and Dockerfile using egeria 3.6 base - to support ongoing demo work.
