### PR TITLE
Fix PostgreSQL connector's bug in creating foreign key links

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ In this example we just pass the jdbc connection url and set ssl to false. The f
                  "connectorType" : 
                  {
                      "class" : "ConnectorType",
-                     "connectorProviderClassName" : "org.odpi.openmetadata.adapters.connectors.integration.postgres.postgresdatabaseprovider"
+                     "connectorProviderClassName" : "org.odpi.openmetadata.adapters.connectors.integration.postgres.PostgresDatabaseProvider"
                      
                  },
                   "recognizedConfigurationProperties": [

--- a/egeria-connector-postgres/src/main/java/org/odpi/openmetadata/adapters/connectors/integration/postgres/PostgresDatabaseConnector.java
+++ b/egeria-connector-postgres/src/main/java/org/odpi/openmetadata/adapters/connectors/integration/postgres/PostgresDatabaseConnector.java
@@ -1502,28 +1502,28 @@ public class PostgresDatabaseConnector extends DatabaseIntegratorConnector
             for (PostgresTable table : tables)
             {
                 List<PostgresForeignKeyLinks> foreignKeys = source.getForeginKeyLinksForTable(table.getTable_name());
-                List<String> importedGuids = new ArrayList<>();
-                List<String> exportedGuids = new ArrayList<>();
 
                 for (PostgresForeignKeyLinks link : foreignKeys)
                 {
-                    List<DatabaseColumnElement> importedEntities = getContext().findDatabaseColumns(link.getImportedColumnQualifiedName(), startFrom, pageSize);
+                    List<String> importedGuids = new ArrayList<>();
+                    List<String> exportedGuids = new ArrayList<>();
+                    List<DatabaseColumnElement> importedEntities = getContext().findDatabaseColumns(".*" + link.getImportedColumnQualifiedName(), startFrom, pageSize);
 
                     if (importedEntities != null)
                     {
                         for (DatabaseColumnElement col : importedEntities)
                         {
-                            importedGuids.add(col.getReferencedColumnGUID());
+                            importedGuids.add(col.getElementHeader().getGUID());
                         }
                     }
 
-                    List<DatabaseColumnElement> exportedEntities = this.getContext().findDatabaseColumns(link.getExportedColumnQualifiedName(), startFrom, pageSize);
+                    List<DatabaseColumnElement> exportedEntities = this.getContext().findDatabaseColumns(".*" + link.getExportedColumnQualifiedName(), startFrom, pageSize);
 
                     if (exportedEntities != null)
                     {
                         for (DatabaseColumnElement col : exportedEntities)
                         {
-                            exportedGuids.add(col.getReferencedColumnGUID());
+                            exportedGuids.add(col.getElementHeader().getGUID());
                         }
                     }
 

--- a/egeria-connector-postgres/src/main/java/org/odpi/openmetadata/adapters/connectors/integration/postgres/PostgresSourceDatabase.java
+++ b/egeria-connector-postgres/src/main/java/org/odpi/openmetadata/adapters/connectors/integration/postgres/PostgresSourceDatabase.java
@@ -174,7 +174,7 @@ public class PostgresSourceDatabase
                 ResultSet rs = stmt.executeQuery(sql);
         ) {
             rs.next();
-            if (rs.getInt("rowcount") == 0) {
+            if (rs.getInt("rowcount") != 0) {
                 result = true;
             }
         }

--- a/egeria-connector-postgres/src/main/java/org/odpi/openmetadata/adapters/connectors/integration/postgres/properties/PostgresForeignKeyLinks.java
+++ b/egeria-connector-postgres/src/main/java/org/odpi/openmetadata/adapters/connectors/integration/postgres/properties/PostgresForeignKeyLinks.java
@@ -30,15 +30,15 @@ public class PostgresForeignKeyLinks
 
     public String getImportedColumnQualifiedName()
     {
-        return table_schema +"." +
-                table_name + "." +
+        return table_schema +"::" +
+                table_name + "::" +
                 column_name ;
     }
 
     public String getExportedColumnQualifiedName()
     {
-        return foreign_table_schema+"." +
-                foreign_table_name + "." +
+        return foreign_table_schema+"::" +
+                foreign_table_name + "::" +
                 foreign_column_name;
     }
 

--- a/egeria-connector-postgres/src/main/java/org/odpi/openmetadata/adapters/connectors/integration/postgres/properties/PostgresTable.java
+++ b/egeria-connector-postgres/src/main/java/org/odpi/openmetadata/adapters/connectors/integration/postgres/properties/PostgresTable.java
@@ -107,7 +107,7 @@ public class PostgresTable {
     }
 
     public String getQualifiedName ( ) {
-        return table_catalog + "." + table_schema + "." + table_type.substring(0,4) + "." + table_name;
+        return table_catalog + "::" + table_schema + "::" + table_type.substring(0,4) + "::" + table_name;
     }
 
     public boolean isEquivalent(DatabaseTableElement element)

--- a/egeria-connector-postgres/src/test/java/org/odpi/openmetadata/adapters/connectors/integration/postgres/properties/PostgresForeginKeyLinksTest.java
+++ b/egeria-connector-postgres/src/test/java/org/odpi/openmetadata/adapters/connectors/integration/postgres/properties/PostgresForeginKeyLinksTest.java
@@ -20,7 +20,7 @@ class PostgresForeginKeyLinksTest {
                                                                     "foregin_column");
 
 
-        assertEquals( link.getImportedColumnQualifiedName(), "table_schema" + "." + "table_name" + "." + "column_name");
+        assertEquals( link.getImportedColumnQualifiedName(), "table_schema" + "::" + "table_name" + "::" + "column_name");
     }
 
     @DisplayName("Test getExportedColumnQualifiedName()")
@@ -35,7 +35,7 @@ class PostgresForeginKeyLinksTest {
                 "foregin_table",
                 "foregin_column");
 
-        assertEquals( link.getExportedColumnQualifiedName(), "foregin_schema" + "." + "foregin_table" + "." + "foregin_column");
+        assertEquals( link.getExportedColumnQualifiedName(), "foregin_schema" + "::" + "foregin_table" + "::" + "foregin_column");
 
     }
 }

--- a/egeria-connector-postgres/src/test/java/org/odpi/openmetadata/adapters/connectors/integration/postgres/properties/PostgresTableTest.java
+++ b/egeria-connector-postgres/src/test/java/org/odpi/openmetadata/adapters/connectors/integration/postgres/properties/PostgresTableTest.java
@@ -285,9 +285,9 @@ class PostgresTableTest {
                 "is_typed",
                 "commit_action");
 
-        String qName = new StringBuilder().append(table.getTable_catalog()).append(".")
-                                            .append(table.getTable_schema()).append(".")
-                                            .append(table.getTable_type().substring(0,4)).append(".")
+        String qName = new StringBuilder().append(table.getTable_catalog()).append("::")
+                                            .append(table.getTable_schema()).append("::")
+                                            .append(table.getTable_type().substring(0,4)).append("::")
                                             .append(table.getTable_name()).toString();
 
         assertEquals( table.getQualifiedName(), qName);


### PR DESCRIPTION
# Bugs
#183 
+ The RelationalColumn assets take `::` as separator in the qualified name. But the previous implementation takes `.` as the separator to find column asset in creating foreign keys.
+ the connector provider name should be `PostgresDatabaseProvider` instead of `postgresdatabaseprovider`, where the configuration cannot find the class with the latter setting.

# About this PR

+ Fix the above bugs.
+ Let PostgreSQL table's qualified name take the `::` as the separator, which follows the same convention as schema and column assets.