### PR TITLE
#180 Correct maven publish - artifact names

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -141,14 +141,14 @@ allprojects {
                         }
                     }
                     scm {
-                        connection = 'scm:git:git://github.com/odpi/egeria.git'
-                        developerConnection = 'scm:git:ssh://github.com/odpi/egeria/egeria.git'
-                        url = 'http://github.com/odpi/egeria'
+                        connection = 'scm:git:https://github.com/odpi/egeria-database-connectors'
+                        developerConnection = 'scm:git:https://github.com/odpi/egeria-database-connectors'
+                        url = 'https://egithub.com/odpi/egeria-database-connectors'
                     }
                 }
                 // Override the project name & description for the pom based on properties set in the child build.gradle (hard to default & required for maven central)
                 pom.withXml {
-                    asNode().appendNode('name', "${project.name}")
+                    //asNode().appendNode('name', "${project.name}")
                     asNode().appendNode('description', "${project.description}")
                 }
             }

--- a/egeria-connector-postgres/build.gradle
+++ b/egeria-connector-postgres/build.gradle
@@ -5,7 +5,6 @@
 
 // Artifact names are taken from the directory by default, set in settings.gradle to override
 // The 'name' for the maven artifact, and description are set here
-ext.name = 'Postgres Connector'
 description = 'Postgres Connector for Egeria'
 
 // Dependencies for this project. Versions set in constraints in root project.

--- a/jdbc-integration-connector/build.gradle
+++ b/jdbc-integration-connector/build.gradle
@@ -5,7 +5,7 @@
 
 // Artifact names are taken from the directory by default, set in settings.gradle to override
 // The 'name' for the maven artifact, and description are set here
-ext.name = 'JDBC Database Integration Connector'
+
 description = 'Egeria integration connector that uses Generic JDBC resource connector to access the database metadata'
 
 dependencies {
@@ -14,6 +14,6 @@ dependencies {
     compileOnly 'org.odpi.egeria:data-manager-api'
     compileOnly 'org.odpi.egeria:database-integrator-api'
     compileOnly 'org.odpi.egeria:open-connector-framework'
-    implementation project(':jdbc-resource-connector')
+    implementation project(':egeria-connector-resource-jdbc')
 }
 

--- a/jdbc-resource-connector/build.gradle
+++ b/jdbc-resource-connector/build.gradle
@@ -5,7 +5,6 @@
 
 // Artifact names are taken from the directory by default, set in settings.gradle to override
 // The 'name' for the maven artifact, and description are set here
-ext.name = 'JDBC Resource Connector'
 description = 'JDBC Resource Connector for Egeria'
 
 dependencies {

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,6 +16,14 @@ pluginManagement {
 rootProject.name = 'egeria-database-connectors'
 
 include(':egeria-connector-postgres')
-include(':jdbc-resource-connector')
-include(':jdbc-integration-connector')
+include(':egeria-connector-resource-jdbc')
+include(':egeria-connector-integration-jdbc')
+include(':egeria-connector-event-mapper-polling-database')
 
+// These define the project names. For now we'll keep them the same as the directory
+// Not needed if we're only going one level deep
+project(':egeria-connector-postgres').projectDir = file('egeria-connector-postgres')
+project(':egeria-connector-resource-jdbc').projectDir = file('jdbc-resource-connector')
+project(':egeria-connector-integration-jdbc').projectDir = file('jdbc-integration-connector')
+project(':egeria-connector-postgres').projectDir = file('egeria-connector-postgres')
+project(':egeria-connector-event-mapper-polling-database').projectDir = file('omrs-database-polling-repository-event-mapper')


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

Updates maven artifact names to follow egeria standards. 

This can be seen in settings.gradle. The original source path is not modified, but the project name is overriden
```
project(':egeria-connector-postgres').projectDir = file('egeria-connector-postgres')
project(':egeria-connector-resource-jdbc').projectDir = file('jdbc-resource-connector')
project(':egeria-connector-integration-jdbc').projectDir = file('jdbc-integration-connector')
project(':egeria-connector-postgres').projectDir = file('egeria-connector-postgres')
project(':egeria-connector-event-mapper-polling-database').projectDir = file('omrs-database-polling-repository-event-mapper')
```

The configuration of the maven publish has been modified to directly use the project name

This will be merged - as the publish process needs to be tested via a main merge